### PR TITLE
Fix: [사이드바 제목 배경상자] - [호버, 선택 시]

### DIFF
--- a/style.css
+++ b/style.css
@@ -82,6 +82,7 @@ textarea {
 }
 .flex:hover {
   background-color: var(--color-border);
+  border-radius: 4px;
 }
 .flex:active {
   background-color: var(--color-border);
@@ -89,7 +90,9 @@ textarea {
 }
 
 .indent {
-  margin-left: 8px;
+  .indent {
+    padding-left: 0; /* .flex와 정렬을 맞추기 위해 */
+  }
   display: none;
 }
 
@@ -121,7 +124,7 @@ textarea {
   padding: 0 8px;
   display: flex;
   flex-direction: column;
-  overflow: hidden; /*김수현 추가*/
+  overflow: hidden;
 }
 
 .side-bar__user {
@@ -130,11 +133,11 @@ textarea {
   font-size: var(--font-size-md);
 }
 .side-bar__wrapper {
-  flex: 1; /* 남은 공간을 채우도록 설정 */
+  flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  overflow-y: auto; /* 사이드바 내에서 스크롤 가능하도록 설정 */
+  overflow-y: auto;
 }
 
 /* 리스트 이름의 길이가 길어지면 말 줄임표로 대체 */


### PR DESCRIPTION
호버와 선택 시 나타나는 변화된 색상의 배경상자의 경우 하위페이지의 왼쪽 기준선을 상위페이지와 맞춰 왼쪽으로 늘리고, 선택되지 않은 호버의 경우에도 배경상자 경계선을 원형으로 주기