### PR TITLE
Fix: rendering.js - 문서 제목이 여러 줄 일때 그대로 출력되는 버그 수정

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1,6 +1,5 @@
-// editor
-
-import { fetchDeleteDocument, navigateTo } from "./utils.js";
+import { navigateTo } from "./router.js";
+import { fetchDeleteDocument } from "./utils.js";
 
 const deleteButton = document.getElementById("icon__delete");
 const deleteModal = document.getElementById("deleteModal");
@@ -107,7 +106,7 @@ confirmDeleteButton.addEventListener("click", async function () {
 
   deleteModal.style.display = "none"; // 모달 닫기
   deleteAlert.style.display = "block"; // 삭제 완료 알림 표시
-  navigateTo(null, "/");
+  navigateTo({ id: docId }, "/");
 });
 
 // 모달의 "취소" 버튼 클릭 시 모달 닫기

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -15,9 +15,9 @@ export const renderEditor = (doc) => {
     }
 
     // 문서 제목과 내용 표시
-    docTitleInput.value = doc.title || "제목 없음";
-    docTitle. = doc.title.split("\n")[0] || "제목 없음";
-    docContents.value = doc.content || "아름다운 글을 작성해보세요!!";
+    docTitleInput.value = doc.title;
+    docTitle.innerText = doc.title.split("\n")[0];
+    docContents.value = doc.content;
   };
 
   displayDocumentContent(doc);

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -1,6 +1,5 @@
 import { createNewPage } from "./sidebar.js";
 import { autoSaveDocument, manualSaveDocument } from "./editor.js";
-import { navigateTo } from "./utils.js";
 
 export const renderEditor = (doc) => {
   console.log("문서 내용 : ", doc);
@@ -17,7 +16,7 @@ export const renderEditor = (doc) => {
 
     // 문서 제목과 내용 표시
     docTitleInput.value = doc.title || "제목 없음";
-    docTitle.innerText = doc.title || "제목 없음";
+    docTitle. = doc.title.split("\n")[0] || "제목 없음";
     docContents.value = doc.content || "아름다운 글을 작성해보세요!!";
   };
 
@@ -82,7 +81,6 @@ export const renderSidebar = (docs) => {
     e.preventDefault();
     const target = e.target;
     const id = target.dataset.id;
-    const pathname = new URL(target.href).pathname;
 
     if (target.tagName === "A") {
       console.log(`클릭한 문서 ID : `, id);
@@ -94,7 +92,6 @@ export const renderSidebar = (docs) => {
 
       // 현재 선택된 문서를 활성화
       target.parentElement.classList.add("selected");
-      navigateTo({ id }, pathname);
     }
   });
 

--- a/src/router.js
+++ b/src/router.js
@@ -1,3 +1,4 @@
+import { autoSaveDocument, manualSaveDocument } from "./editor.js";
 import { renderEditor, renderSidebar } from "./rendering.js";
 import { fetchDocumentContent, fetchDocuments } from "./utils.js";
 
@@ -7,7 +8,9 @@ const render = async (docId = "") => {
   if (pathname === "/") {
     document.getElementById("doc-title__input").value = `🥔 감자의 Notion`;
     document.getElementById("doc__title").innerText = `🥔 감자의 Notion`;
-    document.getElementById("doc-contents").value = `🥔 감자의 Notion에 오신 것을 환영합니다!
+    document.getElementById(
+      "doc-contents"
+    ).value = `🥔 감자의 Notion에 오신 것을 환영합니다!
 작성한 문서를 확인해보세요! 새로운 문서를 추가하거나 기존 문서를 삭제하는 것도 가능합니다.
     `;
     const documents = await fetchDocuments();
@@ -20,8 +23,34 @@ const render = async (docId = "") => {
   }
 };
 
+// 페이지를 렌더링하는 함수
+export const navigateTo = async (state = { id: null }, pathname) => {
+  history.pushState(state, null, pathname);
+
+  if (pathname === "/") {
+    render(state.id);
+  } else {
+    const documentContent = await fetchDocumentContent(state.id);
+    renderEditor(documentContent);
+
+    autoSaveDocument(state.id);
+    manualSaveDocument(state.id);
+  }
+};
+
 // 페이지 로드 시 라우터 실행
 document.addEventListener("DOMContentLoaded", render);
+
+document.body.addEventListener("click", (e) => {
+  e.preventDefault();
+  const target = e.target;
+  const id = target.dataset.id;
+
+  if (target.tagName === "A") {
+    const pathname = new URL(target.href).pathname;
+    navigateTo({ id }, pathname);
+  }
+});
 
 // popstate 이벤트에서 현재 경로를 전달하여 렌더링
 window.addEventListener("popstate", (e) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,3 @@
-import { autoSaveDocument, manualSaveDocument } from "./editor.js";
-import { renderEditor } from "./rendering.js";
-
 const BASE_URL = `https://kdt-api.fe.dev-cos.com/documents`;
 const username = `potatoes`;
 
@@ -39,17 +36,6 @@ export const fetchDocumentContent = async (docId = "") => {
   } catch (error) {
     console.error("문서 내용 요청 실패:", error);
   }
-};
-
-// 페이지를 렌더링하는 함수
-export const navigateTo = async (state = { id: null }, pathname) => {
-  history.pushState(state, null, pathname);
-
-  const documentContent = await fetchDocumentContent(state.id);
-  renderEditor(documentContent);
-
-  autoSaveDocument(state.id);
-  manualSaveDocument(state.id);
 };
 
 export const fetchDeleteDocument = async (docId = "") => {


### PR DESCRIPTION
❗ 변경 사항
---
1. [Fix: rendering.js - 문서 제목이 여러 줄 일때 그대로 출력되는 버그 수정](https://github.com/ddongguri-bing/Potatoes/commit/2704e49ab4aa0ac89343bc21d5f8086ead59129d)
2. [Chore: 에디터 기본 텍스트 삭제](https://github.com/ddongguri-bing/Potatoes/commit/bd6228e984192501271a981888d7842d574c0bf9)
3. [Refactor: utils.js에 있던 navigateTo 함수를 router.js로 이전](https://github.com/ddongguri-bing/Potatoes/commit/01b03b317334af8d24fb6e78b6daed451bde5701)